### PR TITLE
Slider takes value from cex.dotpt if plot is a dotplot 

### DIFF
--- a/R/iNZPlotModWin.R
+++ b/R/iNZPlotModWin.R
@@ -1128,7 +1128,9 @@ iNZPlotMod <- setRefClass(
                 ## OVERALL SIZE
                 lbl <- glabel("Overall :")
                 cexPt <- gslider(from = 0.05, to = 3.5,
-                                 by = 0.05, value = curSet$cex.pt)
+                                 by = 0.05, 
+                                 value = if (PLOTTYPE == "scatter") curSet$cex.pt else curSet$cex.dotpt
+                                 )
                 tbl[ii, 1:2, anchor = c(1, 0), expand = TRUE] <- lbl
                 tbl[ii, 3:6, expand = TRUE] <- cexPt
                 ii <- ii + 1


### PR DESCRIPTION
This fixes iNZightVIT/iNZightPlots#107

(`cex.pt` default is 0.8 vs. `cex.dotpt` is 0.5, so changing anything makes the dotplot points jump up to cex = 0.8)